### PR TITLE
KS-1787: Tweak demo CTA

### DIFF
--- a/components/wrapper/Sidebar.tsx
+++ b/components/wrapper/Sidebar.tsx
@@ -35,7 +35,7 @@ export const SidebarCTA: FC<SidebarCTAProps> = ({ isAttackerMode }) => {
     <div
       className="grid gap-1 justify-items-start"
     >
-      <img
+      {/* <img
         alt="Icon of a shield"
         src="/images/shield.svg"
       />
@@ -45,29 +45,24 @@ export const SidebarCTA: FC<SidebarCTAProps> = ({ isAttackerMode }) => {
           font-medium
         `}
       >
-        Try Keystrike for free
-      </h2>
-      <p
-        className="text-sm text-gray-500 mb-1"
-      >
-        Contact us and get a free 30-day trial, no strings attached!
-      </p>
+        30 day free trial
+      </h2> */}
       <a
         className={`
-        px-4 py-1
-        border border-solid rounded-md
+        p-2
+        w-full
+        rounded-md
         transition-all duration-200 ease-in-out
-        border-gray-200 hover:bg-teal-700 hover:border-teal-700
+        bg-teal-700
         cursor-pointer
         ${textClasses}
-        ${!isAttackerMode && 'hover:text-white'}
-        text-sm font-medium
+        text-md text-center text-white hover:opacity-80
         `}
         href='https://signup.keystrike.com/'
         rel="noopener noreferrer"
         target="_blank"
       >
-        Request a free trial
+        Start your 30 day free trial now!
       </a>
     </div>
   )
@@ -138,7 +133,7 @@ export const SidebarStep: FC<SidebarStepProps> = ({
         {!isFutureStep &&
           <p
           className={`
-            text-gray-600
+            ${isAttackerMode ? "text-gray-400" : "text-gray-600"}
             ${isStepCompleted && "opacity-60"}
           `}
           >


### PR DESCRIPTION
This PR makes the remaining updates to the CTA text, as explained on [this ticket](https://keystrike.atlassian.net/browse/KS-1787) and updated on [this Slack thread](https://garretstudio.slack.com/archives/C060SQ71DC4/p1717410627724259)

**Screenshot:**

![Screenshot 2024-06-04 at 07-48-22 Keystrike Demo](https://github.com/Integrikey/webOS/assets/34423371/ed2f84d1-fb2c-43f1-900e-6c88207cbd3c)
